### PR TITLE
fix(bot): return message only when successful

### DIFF
--- a/src/client.cr
+++ b/src/client.cr
@@ -73,9 +73,10 @@ module Crudris
       }.to_json
 
       if resp.status_code == 200
-        return JSON.parse resp.body
+        return JSON.parse(resp.body)
       else
-        return # TODO: Use Log.exception and implement this better when #1 gets merged
+        data = JSON.parse(resp.body)["data"] # To make the code more readable.
+        Log.error(exception: Exception.new(data["error"].to_s)) { "Error while creating message." }
       end
     end
   end

--- a/src/client.cr
+++ b/src/client.cr
@@ -65,7 +65,12 @@ module Crudris
         "author"  => @author_name,
         "content" => content,
       }.to_json
-      return JSON.parse resp.body
+
+	  if resp.status_code == 200
+		return JSON.parse resp.body
+	  else
+		return # TODO: Use Log.exception and implement this better when #1 gets merged
+	  end
     end
   end
 end

--- a/src/client.cr
+++ b/src/client.cr
@@ -66,11 +66,11 @@ module Crudris
         "content" => content,
       }.to_json
 
-	  if resp.status_code == 200
-		return JSON.parse resp.body
-	  else
-		return # TODO: Use Log.exception and implement this better when #1 gets merged
-	  end
+      if resp.status_code == 200
+        return JSON.parse resp.body
+      else
+        return # TODO: Use Log.exception and implement this better when #1 gets merged
+      end
     end
   end
 end

--- a/src/client.cr
+++ b/src/client.cr
@@ -76,7 +76,8 @@ module Crudris
         return JSON.parse(resp.body)
       else
         data = JSON.parse(resp.body)["data"] # To make the code more readable.
-        Log.error(exception: Exception.new(data["error"].to_s)) { "Error while creating message." }
+        Log.error { "Error while creating message." }
+        raise data["error"].to_s
       end
     end
   end


### PR DESCRIPTION
This makes `create_message` only return the response when it is successfull (When the response returns 200 to be specific). Instead of regardless of what happens.

This initially returned something along the lines of `{"error" => "error message"}`, which makes it look like it is a success. In future, it will make use of `Log` that is implemented in #1 once merged.